### PR TITLE
Features set rtp port range

### DIFF
--- a/tinyMEDIA/src/tmedia_defaults.c
+++ b/tinyMEDIA/src/tmedia_defaults.c
@@ -58,8 +58,8 @@ static int32_t __audio_consumer_gain = 0;
 static int32_t __audio_channels_playback = 1;
 static int32_t __audio_channels_record = 1;
 static int32_t __audio_ptime = 20;
-static uint16_t __rtp_port_range_start = 1024;
-static uint16_t __rtp_port_range_stop = 65535;
+static uint16_t __rtp_port_range_start = 40000;
+static uint16_t __rtp_port_range_stop = 49999;
 static tsk_bool_t __rtp_symetric_enabled = tsk_false; // This option is force symetric RTP for remote size. Local: always ON
 static tmedia_type_t __media_type = tmedia_audio;
 static int32_t __volume = 100;
@@ -439,6 +439,7 @@ int tmedia_defaults_set_rtp_port_range(uint16_t start, uint16_t stop)
         TSK_DEBUG_ERROR("Invalid parameter: (%u < 1024 || %u < 1024 || %u >= %u)", start, stop, start, stop);
         return -1;
     }
+    TSK_DEBUG_INFO("Set rtp port range: %u to %u", start, stop);
     __rtp_port_range_start = start;
     __rtp_port_range_stop = stop;
     return 0;

--- a/tinyNET/src/ice/tnet_ice_utils.c
+++ b/tinyNET/src/ice/tnet_ice_utils.c
@@ -82,14 +82,17 @@ int tnet_ice_utils_create_sockets(tnet_socket_type_t socket_type, const char* lo
     tsk_bool_t look4_rtcp = (socket_rtcp != tsk_null);
     uint8_t retry_count = 10;
     tnet_port_t local_port;
-    static const uint64_t port_range_start = 1024;
-    static const uint64_t port_range_stop = (65535 - 1/* to be sure rtcp port will be valid */);
+    static const uint64_t port_range_start = 40000;
+    static const uint64_t port_range_stop = (50000 - 1/* to be sure rtcp port will be valid */);
     static uint64_t counter = 0;
 
     /* Creates local rtp and rtcp sockets */
     while(retry_count--) {
+        TSK_DEBUG_INFO("trying create sockets retry_count: %u ", 10 - retry_count);
         if(look4_rtp && look4_rtcp) {
-            tnet_socket_t* socket_fake = tnet_socket_create(local_ip, TNET_SOCKET_PORT_ANY, socket_type);
+            tnet_port_t port = (tnet_port_t)((((tsk_time_epoch() + rand() ) ^ ++counter) % (port_range_stop - port_range_start)) + port_range_start);
+            TSK_DEBUG_INFO("random local port between %u and %u", port_range_start, port_range_stop);
+            tnet_socket_t* socket_fake = tnet_socket_create(local_ip, port, socket_type);
             if(!socket_fake) {
                 continue;
             }
@@ -104,6 +107,7 @@ int tnet_ice_utils_create_sockets(tnet_socket_type_t socket_type, const char* lo
         else {
             local_port = (tnet_port_t)((((tsk_time_epoch() + rand() ) ^ ++counter) % (port_range_stop - port_range_start)) + port_range_start);
             local_port = (local_port & 0xFFFE); /* turn to even number */
+            TSK_DEBUG_INFO("random local port between %u and %u", port_range_start, port_range_stop);
         }
 
         /* beacuse failure will cause errors in the log, print a message to alert that there is
@@ -126,7 +130,7 @@ int tnet_ice_utils_create_sockets(tnet_socket_type_t socket_type, const char* lo
                 continue;
             }
         }
-
+        
         TSK_DEBUG_INFO("RTP/RTCP manager[End]: Trying to bind to random ports");
         return 0;
     }


### PR DESCRIPTION
# Doubango log
This version will random RTP/RTCP port range between 4000 and 49999

```
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 40855
```

```
root@doubango-ubuntu-s-1804x64:/opt/doubango# webrtc2sip --config=/opt/doubango/conf/config-with-ssl.xml
*******************************************************************
Copyright (C) 2012-2015 Doubango Telecom <http://www.doubango.org>
PRODUCT: webrtc2sip
HOME PAGE: http://webrtc2sip.org
LICENCE: GPLv3 or proprietary
VERSION: 2.7.0
'quit' to quit the application.
*******************************************************************

SSL is enabled :)
DTLS supported: yes
DTLS-SRTP supported: yes
*[DOUBANGO INFO]: transport = udp://*:10060
*[DOUBANGO INFO]: transport = ws://*:10060
*[DOUBANGO INFO]: transport = wss://*:10062
*[DOUBANGO INFO]: enable-rtp-symetric = yes
*[DOUBANGO INFO]: enable-100rel = no
*[DOUBANGO INFO]: enable-media-coder = no
*[DOUBANGO INFO]: enable-videojb = yes
*[DOUBANGO INFO]: video-size-pref = vga
*[DOUBANGO INFO]: rtp-buffsize = 65535
*[DOUBANGO INFO]: avpf-tail-length = [100-400]
*[DOUBANGO INFO]: srtp-mode = optional
*[DOUBANGO INFO]: srtp-type = sdes;dtls
*[DOUBANGO INFO]: dtmf-type = rfc4733
*[DOUBANGO INFO]: codecs = pcma;opus;pcmu;gsm;vp8;h264-bp;h264-mp;h263;h263+
*[DOUBANGO INFO]: UnRegister codec: PCMA, G.711a codec (native)
*[DOUBANGO INFO]: UnRegister codec: PCMU, G.711u codec (native)
*[DOUBANGO INFO]: UnRegister codec: GSM, GSM Full Rate (libgsm)
*[DOUBANGO INFO]: UnRegister codec: VP8, VP8 codec (libvpx)
*[DOUBANGO INFO]: UnRegister codec: H264, H264 Base Profile (OpenH264)
*[DOUBANGO INFO]: 'h264-mp' codec enabled but not supported
*[DOUBANGO INFO]: UnRegister codec: H263, H263-1996 codec (FFmpeg)
*[DOUBANGO INFO]: UnRegister codec: H263-1998, H263-1998 codec (FFmpeg)
*[DOUBANGO INFO]: codec-opus-maxrates = 48000;48000
*[DOUBANGO INFO]: stun-server = sbc2.entro-lab.com;3478;-;-
*[DOUBANGO INFO]: enable-icestun = yes
*[DOUBANGO INFO]: max-fds = -1
*[DOUBANGO INFO]: ssl-certificates = 
/etc/ssl/entro-lab.com/privkey.pem;
/etc/ssl/entro-lab.com/cert.pem;
/etc/ssl/entro-lab.com/fullchain.pem;
no
*[DOUBANGO INFO]: database = sqlite;*
*[DOUBANGO INFO]: sqlite3_threadsafe = 1
*[DOUBANGO INFO]: Database opened = TRUE
*[DOUBANGO INFO]: Stack running in SERVER mode
*[DOUBANGO INFO]: tsk_timer_manager_start
*[DOUBANGO INFO]: Timer manager run()::enter
*[DOUBANGO INFO]: TIMER MANAGER -- START
*[DOUBANGO INFO]: Best source at 0: 134.209.96.220
*[DOUBANGO INFO]: Best source at 4: 134.209.96.220
*[DOUBANGO INFO]: Best source at 5: 134.209.96.220
*[DOUBANGO INFO]: tnet_transport_prepare()
*[DOUBANGO INFO]: pipeR fd=9, pipeW=10
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=9, tail.count=1
*[DOUBANGO INFO]: master fd=6
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=6, tail.count=2
*[DOUBANGO INFO]: tnet_transport_prepare()
*[DOUBANGO INFO]: pipeR fd=11, pipeW=12
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=11, tail.count=1
*[DOUBANGO INFO]: master fd=7
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=7, tail.count=2
*[DOUBANGO INFO]: tnet_transport_prepare()
*[DOUBANGO INFO]: pipeR fd=13, pipeW=14
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=13, tail.count=1
*[DOUBANGO INFO]: master fd=8
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=8, tail.count=2
*[DOUBANGO INFO]: SIP STACK -- START
*[DOUBANGO INFO]: Transport::run(SIP transport) - enter
*[DOUBANGO INFO]: Transport::run(SIP transport) - enter
*[DOUBANGO INFO]: Transport::run(SIP transport) - enter
*[DOUBANGO INFO]: Starting [SIP transport] server with IP {134.209.96.220} on port {10062} using master fd {8} with type {128} with max_fds {1024}...
*[DOUBANGO INFO]: Starting [SIP transport] server with IP {134.209.96.220} on port {10060} using master fd {7} with type {64} with max_fds {1024}...
*[DOUBANGO INFO]: SIP STACK::run -- START
*[DOUBANGO INFO]: Starting [SIP transport] server with IP {134.209.96.220} on port {10060} using master fd {6} with type {2} with max_fds {1024}...

*[DOUBANGO INFO]: ioctlt(8), len=0 returned zero or failed
*[DOUBANGO INFO]: NETWORK EVENT FOR SERVER [SIP transport] -- FD_ACCEPT(fd=15)
*[DOUBANGO INFO]: Socket added[SIP transport]: fd=15, tail.count=3
*[DOUBANGO INFO]: WebSocket Peer accepted/connected with fd = 15
*[DOUBANGO INFO]: #1 peers in the 'SIP transport' transport
*[DOUBANGO INFO]: NETWORK EVENT FOR SERVER [SIP transport] -- TNET_POLLOUT
*[DOUBANGO INFO]: WebSocket Peer accepted/connected with fd = 15
*[DOUBANGO INFO]: Peer with local fd=15 already exist
*[DOUBANGO INFO]: #0 peers in the 'SIP transport' transport
*[DOUBANGO INFO]: #1 peers in the 'SIP transport' transport
*[DOUBANGO INFO]: WebSocket handshake message: GET / HTTP/1.1
Host: sbc-staging.entro-lab.com:10062
Connection: Upgrade
Pragma: no-cache
Cache-Control: no-cache
Upgrade: websocket
Origin: https://www.doubango.org
Sec-WebSocket-Version: 13
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36
Accept-Encoding: gzip, deflate, br
Accept-Language: th,en-US;q=0.9,en;q=0.8
Sec-WebSocket-Key: HO+diHqo0tcm+0sDW3po4A==
Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
Sec-WebSocket-Protocol: sip


*[DOUBANGO INFO]: Receiving SIP o/ WebSocket message: REGISTER sip:178.128.23.171:5060 SIP/2.0
Via: SIP/2.0/WSS df7jal23ls0d.invalid;branch=z9hG4bKMbQUCxUbQ4gCVkPJxpv6aMUyMrZlsGVR;rport
From: "test"<sip:test@178.128.23.171:5060>;tag=AvDXTKBLRRBsq27Xr2k2
To: "test"<sip:test@178.128.23.171:5060>
Contact: "test"<sips:test@df7jal23ls0d.invalid;rtcweb-breaker=yes;transport=wss>;expires=200;click2call=no;+g.oma.sip-im;+audio;language="en,fr"
Call-ID: e2d4647a-9b42-3eb5-2a21-0cee1c2a4f9e
CSeq: 55719 REGISTER
Content-Length: 0
Route: <sip:178.128.23.171:5060;lr;sipml5-outbound;transport=udp>
Max-Forwards: 70
User-Agent: IM-client/OMA1.0 sipML5-v1.2016.03.04
Organization: Doubango Telecom
Supported: path


*[DOUBANGO INFO]: State machine: tsip_transac_nict_Started_2_Trying_X_send
*[DOUBANGO INFO]: 

SEND: REGISTER sip:178.128.23.171:5060 SIP/2.0
Via: SIP/2.0/UDP 134.209.96.220:10060;branch=z9hG4bKMbQUCxUbQ4gCVkPJxpv6aMUyMrZlsGVR;rport
From: "test"<sip:test@178.128.23.171:5060>;tag=AvDXTKBLRRBsq27Xr2k2
To: "test"<sip:test@178.128.23.171:5060>
Contact: "test"<sip:test@134.209.96.220:10060;rtcweb-breaker=yes;transport=udp;ws-src-ip=180.183.42.233;ws-src-port=6437;ws-src-proto=wss>;expires=200;click2call=no;+g.oma.sip-im;+audio;language="en,fr"
Call-ID: e2d4647a-9b42-3eb5-2a21-0cee1c2a4f9e
CSeq: 55719 REGISTER
Content-Length: 0
Max-Forwards: 70
User-Agent: IM-client/OMA1.0 sipML5-v1.2016.03.04
Organization: Doubango Telecom
Supported: path
Via: SIP/2.0/TCP 180.183.42.233:6437;rport;branch=z9hG4bKMbQUCxUbQ4gCVkPJxpv6aMUyMrZlsGVR;ws-hacked=WSS




*[DOUBANGO INFO]: 

RECV:SIP/2.0 200 OK
Via: SIP/2.0/UDP 134.209.96.220:10060;branch=z9hG4bKMbQUCxUbQ4gCVkPJxpv6aMUyMrZlsGVR;rport=10060;received=134.209.96.220
From: "test"<sip:test@178.128.23.171:5060>;tag=AvDXTKBLRRBsq27Xr2k2
To: "test"<sip:test@178.128.23.171:5060>;tag=9dd61ff61e802d8e2bef5f14621ef3c2.7575
Call-ID: e2d4647a-9b42-3eb5-2a21-0cee1c2a4f9e
CSeq: 55719 REGISTER
Via: SIP/2.0/TCP 180.183.42.233:6437;rport;branch=z9hG4bKMbQUCxUbQ4gCVkPJxpv6aMUyMrZlsGVR;ws-hacked=WSS
Contact: <sip:test@134.209.96.220:10060;rtcweb-breaker=yes;transport=udp;ws-src-ip=180.183.42.233;ws-src-port=26522;ws-src-proto=wss>;expires=19, <sip:test@134.209.96.220:10060;rtcweb-breaker=yes;transport=udp;ws-src-ip=180.183.42.233;ws-src-port=6437;ws-src-proto=wss>;expires=200
Server: kamailio (5.2.1 (x86_64/linux))
Content-Length: 0




*[DOUBANGO INFO]: State machine: tsip_transac_nict_Trying_2_Completed_X_200_to_699
*[DOUBANGO INFO]: State machine: tsip_transac_nict_Completed_2_Terminated_X_timerK
*[DOUBANGO INFO]: === NICT terminated ===
*[DOUBANGO INFO]: *** NICT destroyed ***
*[DOUBANGO INFO]: Receiving SIP o/ WebSocket message: INVITE sip:pepsi@178.128.23.171 SIP/2.0
Via: SIP/2.0/WSS df7jal23ls0d.invalid;branch=z9hG4bKQDozztRmTUGZRtIXWxnITHwknhyCPEss;rport
From: "test"<sip:test@178.128.23.171:5060>;tag=lZ1KaBZ0p7LHlBqi8z5Z
To: <sip:pepsi@178.128.23.171>
Contact: "test"<sips:test@df7jal23ls0d.invalid;rtcweb-breaker=yes;click2call=no;transport=wss>;impi=test;ha1=145f01391445567ab9a8af69881e8f59;+g.oma.sip-im;language="en,fr"
Call-ID: 1e8276e8-a73f-7932-f276-b791493df407
CSeq: 43325 INVITE
Content-Type: application/sdp
Content-Length: 6747
Route: <sip:178.128.23.171:5060;lr;sipml5-outbound;transport=udp>
Max-Forwards: 70
User-Agent: IM-client/OMA1.0 sipML5-v1.2016.03.04
Organization: Doubango Telecom

v=0
o=- 3912141801517111300 2 IN IP4 127.0.0.1
s=Doubango Telecom - chrome
t=0 0
a=group:BUNDLE 0 1
a=msid-semantic: WMS 7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s
m=audio 51069 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126
c=IN IP4 192.168.104.77
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:1436999646 1 udp 2122260223 192.168.104.77 51069 typ host generation 0 network-id 2 network-cost 50
a=candidate:607528754 1 udp 2122194687 192.168.100.101 61342 typ host generation 0 network-id 1 network-cost 10
a=candidate:455418670 1 tcp 1518280447 192.168.104.77 9 typ host tcptype active generation 0 network-id 2 network-cost 50
a=candidate:1790303170 1 tcp 1518214911 192.168.100.101 9 typ host tcptype active generation 0 network-id 1 network-cost 10
a=ice-ufrag:Gamt
a=ice-pwd:uPKFivtYz5NeQiQqIbF7XEPe
a=ice-options:trickle
a=fingerprint:sha-256 76:E4:74:76:58:0E:48:D2:EA:D5:09:A8:AC:34:BF:D6:62:9E:6B:CA:2F:56:34:1B:0D:D5:E8:27:A3:5D:F0:EA
a=setup:actpass
a=mid:0
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
a=sendrecv
a=msid:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s 5984b390-aff1-49c5-bc0b-ce5f43499efb
a=rtcp-mux
a=rtpmap:111 opus/48000/2
a=rtcp-fb:111 transport-cc
a=fmtp:111 minptime=10;useinbandfec=1
a=rtpmap:103 ISAC/16000
a=rtpmap:104 ISAC/32000
a=rtpmap:9 G722/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:106 CN/32000
a=rtpmap:105 CN/16000
a=rtpmap:13 CN/8000
a=rtpmap:110 telephone-event/48000
a=rtpmap:112 telephone-event/32000
a=rtpmap:113 telephone-event/16000
a=rtpmap:126 telephone-event/8000
a=ssrc:1504478099 cname:p2RZvDlmpdWDWfrV
a=ssrc:1504478099 msid:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s 5984b390-aff1-49c5-bc0b-ce5f43499efb
a=ssrc:1504478099 mslabel:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s
a=ssrc:1504478099 label:5984b390-aff1-49c5-bc0b-ce5f43499efb
m=video 64190 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 122 127 121 125 107 108 109 124 120 123 119 114 115 116
c=IN IP4 192.168.104.77
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:1436999646 1 udp 2122260223 192.168.104.77 64190 typ host generation 0 network-id 2 network-cost 50
a=candidate:607528754 1 udp 2122194687 192.168.100.101 51878 typ host generation 0 network-id 1 network-cost 10
a=candidate:455418670 1 tcp 1518280447 192.168.104.77 9 typ host tcptype active generation 0 network-id 2 network-cost 50
a=candidate:1790303170 1 tcp 1518214911 192.168.100.101 9 typ host tcptype active generation 0 network-id 1 network-cost 10
a=ice-ufrag:Gamt
a=ice-pwd:uPKFivtYz5NeQiQqIbF7XEPe
a=ice-options:trickle
a=fingerprint:sha-256 76:E4:74:76:58:0E:48:D2:EA:D5:09:A8:AC:34:BF:D6:62:9E:6B:CA:2F:56:34:1B:0D:D5:E8:27:A3:5D:F0:EA
a=setup:actpass
a=mid:1
a=extmap:14 urn:ietf:params:rtp-hdrext:toffset
a=extmap:13 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:12 urn:3gpp:video-orientation
a=extmap:2 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:11 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
a=extmap:8 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07
a=extmap:9 http://www.webrtc.org/experiments/rtp-hdrext/color-space
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
a=sendrecv
a=msid:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s e474ee09-b165-466f-8561-78851eeac9d6
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:96 VP8/90000
a=rtcp-fb:96 goog-remb
a=rtcp-fb:96 transport-cc
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=rtpmap:97 rtx/90000
a=fmtp:97 apt=96
a=rtpmap:98 VP9/90000
a=rtcp-fb:98 goog-remb
a=rtcp-fb:98 transport-cc
a=rtcp-fb:98 ccm fir
a=rtcp-fb:98 nack
a=rtcp-fb:98 nack pli
a=fmtp:98 profile-id=0
a=rtpmap:99 rtx/90000
a=fmtp:99 apt=98
a=rtpmap:100 VP9/90000
a=rtcp-fb:100 goog-remb
a=rtcp-fb:100 transport-cc
a=rtcp-fb:100 ccm fir
a=rtcp-fb:100 nack
a=rtcp-fb:100 nack pli
a=fmtp:100 profile-id=2
a=rtpmap:101 rtx/90000
a=fmtp:101 apt=100
a=rtpmap:102 H264/90000
a=rtcp-fb:102 goog-remb
a=rtcp-fb:102 transport-cc
a=rtcp-fb:102 ccm fir
a=rtcp-fb:102 nack
a=rtcp-fb:102 nack pli
a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
a=rtpmap:122 rtx/90000
a=fmtp:122 apt=102
a=rtpmap:127 H264/90000
a=rtcp-fb:127 goog-remb
a=rtcp-fb:127 transport-cc
a=rtcp-fb:127 ccm fir
a=rtcp-fb:127 nack
a=rtcp-fb:127 nack pli
a=fmtp:127 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f
a=rtpmap:121 rtx/90000
a=fmtp:121 apt=127
a=rtpmap:125 H264/90000
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 transport-cc
a=rtcp-fb:125 ccm fir
a=rtcp-fb:125 nack
a=rtcp-fb:125 nack pli
a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
a=rtpmap:107 rtx/90000
a=fmtp:107 apt=125
a=rtpmap:108 H264/90000
a=rtcp-fb:108 goog-remb
a=rtcp-fb:108 transport-cc
a=rtcp-fb:108 ccm fir
a=rtcp-fb:108 nack
a=rtcp-fb:108 nack pli
a=fmtp:108 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f
a=rtpmap:109 rtx/90000
a=fmtp:109 apt=108
a=rtpmap:124 H264/90000
a=rtcp-fb:124 goog-remb
a=rtcp-fb:124 transport-cc
a=rtcp-fb:124 ccm fir
a=rtcp-fb:124 nack
a=rtcp-fb:124 nack pli
a=fmtp:124 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d0032
a=rtpmap:120 rtx/90000
a=fmtp:120 apt=124
a=rtpmap:123 H264/90000
a=rtcp-fb:123 goog-remb
a=rtcp-fb:123 transport-cc
a=rtcp-fb:123 ccm fir
a=rtcp-fb:123 nack
a=rtcp-fb:123 nack pli
a=fmtp:123 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032
a=rtpmap:119 rtx/90000
a=fmtp:119 apt=123
a=rtpmap:114 red/90000
a=rtpmap:115 rtx/90000
a=fmtp:115 apt=114
a=rtpmap:116 ulpfec/90000
a=ssrc-group:FID 1732783109 1907411937
a=ssrc:1732783109 cname:p2RZvDlmpdWDWfrV
a=ssrc:1732783109 msid:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s e474ee09-b165-466f-8561-78851eeac9d6
a=ssrc:1732783109 mslabel:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s
a=ssrc:1732783109 label:e474ee09-b165-466f-8561-78851eeac9d6
a=ssrc:1907411937 cname:p2RZvDlmpdWDWfrV
a=ssrc:1907411937 msid:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s e474ee09-b165-466f-8561-78851eeac9d6
a=ssrc:1907411937 mslabel:7TPicIhUAjEGQTxZOkUFRddgVjU2cT54rc1s
a=ssrc:1907411937 label:e474ee09-b165-466f-8561-78851eeac9d6

*[DOUBANGO INFO]: State machine: tsip_transac_ist_Started_2_Proceeding_X_INVITE
*[DOUBANGO INFO]: Add call-id = '1e8276e8-a73f-7932-f276-b791493df407' to peer with local fd = 15
*[DOUBANGO INFO]: State machine: x0500_Current_2_Current_X_iINVITE
*[DOUBANGO INFO]: tnet_ice_ctx_set_remote_candidates(ufrag=Gamt, pwd=uPKFivtYz5NeQiQqIbF7XEPe, is_controlling=0, is_ice_jingle=0, use_rtcpmux=1)
*[DOUBANGO INFO]: tnet_ice_ctx_set_remote_candidates(ufrag=Gamt, pwd=uPKFivtYz5NeQiQqIbF7XEPe, is_controlling=0, is_ice_jingle=0, use_rtcpmux=1)
*[DOUBANGO INFO]: tnet_ice_ctx_start
*[DOUBANGO INFO]: tsk_timer_manager_start
*[DOUBANGO INFO]: tnet_ice_ctx_start
*[DOUBANGO INFO]: tsk_timer_manager_start
*[DOUBANGO INFO]: ICE CTX::run -- START
*[DOUBANGO INFO]: State machine: ICE_Started_2_GatheringHostCandidates_X_GatherHostCandidates
*[DOUBANGO INFO]: Timer manager run()::enter
*[DOUBANGO INFO]: ICE CTX::run -- START
*[DOUBANGO INFO]: State machine: ICE_Started_2_GatheringHostCandidates_X_GatherHostCandidates
*[DOUBANGO INFO]: Timer manager run()::enter
*[DOUBANGO INFO]: TIMER MANAGER -- START
*[DOUBANGO INFO]: TIMER MANAGER -- START
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 44517
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.130.109.245:44516]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.130.109.245
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 44244
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [134.209.96.220:44244]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 134.209.96.220
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 40856
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.15.0.17:40856]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.15.0.17
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidates_2_GatheringHostCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE-STUN enabled and we have STUN servers
*[DOUBANGO INFO]: ICE callback: Gathering host candidates succeed
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidatesDone_2_GatheringReflexiveCandidates_X_GatherReflexiveCandidates
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=0,rto=0
*[DOUBANGO INFO]: STUN request timedout at 0, rc = 3, rto=0
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 41533
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.130.109.245:41532]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.130.109.245
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 49959
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [134.209.96.220:49958]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 134.209.96.220
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 40855
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.15.0.17:40854]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.15.0.17
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidates_2_GatheringHostCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE-STUN enabled and we have STUN servers
*[DOUBANGO INFO]: ICE callback: Gathering host candidates succeed
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidatesDone_2_GatheringReflexiveCandidates_X_GatherReflexiveCandidates
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=0,rto=0
*[DOUBANGO INFO]: STUN request timedout at 0, rc = 3, rto=0
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=44244, fd=19, already_skipped(0)=no
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=44245, fd=17, already_skipped(1)=no
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=49958, fd=25, already_skipped(0)=no
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=49959, fd=24, already_skipped(1)=no
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: STUN request timedout at 3, rc = 3, rto=500
*[DOUBANGO INFO]: srflx_addr_count_added=0, srflx_addr_count_skipped=2
*[DOUBANGO INFO]: Candidate: DMByIuBpaynWhF4 1 udp 2130706431 134.209.96.220 44244 typ host tr udp fd 19
*[DOUBANGO INFO]: Candidate: oRyBtm7tGvIrAgm 1 udp 2130706175 10.130.109.245 44516 typ host tr udp fd 18
*[DOUBANGO INFO]: Candidate: oRyBtm7tGvIrAgm 2 udp 2130706174 10.130.109.245 44517 typ host tr udp fd 16
*[DOUBANGO INFO]: Candidate: DMByIuBpaynWhF4 2 udp 2130706430 134.209.96.220 44245 typ host tr udp fd 17
*[DOUBANGO INFO]: Candidate: 7faonVcNKFz44lP 1 udp 2130705919 10.15.0.17 40856 typ host tr udp fd 20
*[DOUBANGO INFO]: Candidate: 7faonVcNKFz44lP 2 udp 2130705918 10.15.0.17 40857 typ host tr udp fd 21
*[DOUBANGO INFO]: State machine: ICE_fsm_GatheringReflexiveCandidates_2_GatheringReflexiveCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE callback: Gathering reflexive candidates succeed
*[DOUBANGO INFO]: State machine: ICE_Any_2_GatheringCompleted_X_GatheringComplet
*[DOUBANGO INFO]: ICE callback: Gathering candidates completed
*[DOUBANGO INFO]: State machine: ICE_GatheringCompleted_2_ConnChecking_X_ConnCheck
*[DOUBANGO INFO]: ICE: begin building pairs(is_rtcpmuxed=1)
*[DOUBANGO INFO]: ICE Pair(1, 9115038255648079870): [DMByIuBpaynWhF4 2130706431 1 134.209.96.220 44244] -> [1436999646 2122260223 1 192.168.104.77 64190]
*[DOUBANGO INFO]: ICE Pair(2, 9114756780671369214): [DMByIuBpaynWhF4 2130706431 1 134.209.96.220 44244] -> [607528754 2122194687 1 192.168.100.101 51878]
*[DOUBANGO INFO]: ICE Pair(3, 9115038255648079358): [oRyBtm7tGvIrAgm 2130706175 1 10.130.109.245 44516] -> [1436999646 2122260223 1 192.168.104.77 64190]
*[DOUBANGO INFO]: ICE Pair(4, 9114756780671368702): [oRyBtm7tGvIrAgm 2130706175 1 10.130.109.245 44516] -> [607528754 2122194687 1 192.168.100.101 51878]
*[DOUBANGO INFO]: ICE Pair(5, 9115038255648078846): [7faonVcNKFz44lP 2130705919 1 10.15.0.17 40856] -> [1436999646 2122260223 1 192.168.104.77 64190]
*[DOUBANGO INFO]: ICE Pair(6, 9114756780671368190): [7faonVcNKFz44lP 2130705919 1 10.15.0.17 40856] -> [607528754 2122194687 1 192.168.100.101 51878]
*[DOUBANGO INFO]: ICE: end building pairs
*[DOUBANGO INFO]: STUN request timedout at 3, rc = 3, rto=500
*[DOUBANGO INFO]: srflx_addr_count_added=0, srflx_addr_count_skipped=2
*[DOUBANGO INFO]: Candidate: tK09uR7JfWunKSj 1 udp 2130706431 134.209.96.220 49958 typ host tr udp fd 25
*[DOUBANGO INFO]: Candidate: xc9MKNDCUKVRdSc 1 udp 2130706175 10.130.109.245 41532 typ host tr udp fd 23
*[DOUBANGO INFO]: Candidate: xc9MKNDCUKVRdSc 2 udp 2130706174 10.130.109.245 41533 typ host tr udp fd 22
*[DOUBANGO INFO]: Candidate: tK09uR7JfWunKSj 2 udp 2130706430 134.209.96.220 49959 typ host tr udp fd 24
*[DOUBANGO INFO]: Candidate: n1C39wtUotIjZ2m 1 udp 2130705919 10.15.0.17 40854 typ host tr udp fd 27
*[DOUBANGO INFO]: Candidate: n1C39wtUotIjZ2m 2 udp 2130705918 10.15.0.17 40855 typ host tr udp fd 26
*[DOUBANGO INFO]: State machine: ICE_fsm_GatheringReflexiveCandidates_2_GatheringReflexiveCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE callback: Gathering reflexive candidates succeed
*[DOUBANGO INFO]: State machine: ICE_Any_2_GatheringCompleted_X_GatheringComplet
*[DOUBANGO INFO]: ICE callback: Gathering candidates completed
*[DOUBANGO INFO]: ICE: ignore processing SDP RO because version haven't changed
*[DOUBANGO INFO]: m_lines_count=0,
is_dtls_fingerprint_changed=0,
is_sdes_crypto_changed=0,
is_ice_enabled=0,
is_ice_restart=0,
is_ro_hold_resume_changed=0,
is_ro_provisional_final_matching=0,
is_ro_media_lines_changed=0,
is_ro_network_info_changed=0,
is_ro_loopback_address=0,
is_media_type_changed=0,
is_ro_codecs_changed=0
is_local_encoder_still_ok=0

*[DOUBANGO INFO]: tdav_consumer_audio_init()
*[DOUBANGO INFO]: Create SpeexDSP denoiser
*[DOUBANGO INFO]: Create SpeexDSP jitter buffer
*[DOUBANGO INFO]: Video 'zero-artifacts' option = no
*[DOUBANGO INFO]: *** tdav_codec_vp8_dtor destroyed ***
*[DOUBANGO INFO]: tdav_codec_vp8_close_encoder(begin)
*[DOUBANGO INFO]: tdav_codec_vp8_close_encoder(end)
*[DOUBANGO INFO]: tdav_codec_vp8_close_decoder(begin)
*[DOUBANGO INFO]: tdav_codec_vp8_close_decoder(end)
*[DOUBANGO INFO]: tdav_codec_h264_common_deinit
*[DOUBANGO INFO]: new m_lines_count = 0 -> 2
*[DOUBANGO INFO]: ICE enabled on RTP manager
*[DOUBANGO INFO]: Remote SSRC = 1504478099
*[DOUBANGO INFO]: dtls.remote.setup=actpass
*[DOUBANGO INFO]: ICE enabled on RTP manager
*[DOUBANGO INFO]: Remote SSRC = 1732783109
*[DOUBANGO INFO]: dtls.remote.setup=actpass
*[DOUBANGO INFO]: [OPUS] Trying to match [fmtp:minptime=10;useinbandfec=1]
*[DOUBANGO INFO]: [H.264] Trying to match [fmtp:level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f]
*[DOUBANGO INFO]: State machine: s0000_Started_2_Ringing_X_iINVITE
*[DOUBANGO INFO]: State machine: tsip_transac_ist_Proceeding_2_Proceeding_X_1xx
*[DOUBANGO INFO]: Negotiated codecs with the left leg = 68165728
*[DOUBANGO INFO]: State machine: x0500_Current_2_Current_X_oINVITE
*[DOUBANGO INFO]: tnet_ice_ctx_start
*[DOUBANGO INFO]: tsk_timer_manager_start
*[DOUBANGO INFO]: tnet_ice_ctx_start
*[DOUBANGO INFO]: tsk_timer_manager_start
*[DOUBANGO INFO]: State machine: ICE_GatheringCompleted_2_ConnChecking_X_ConnCheck
*[DOUBANGO INFO]: ICE: begin building pairs(is_rtcpmuxed=1)
*[DOUBANGO INFO]: ICE Pair(7, 9115038255648079870): [tK09uR7JfWunKSj 2130706431 1 134.209.96.220 49958] -> [1436999646 2122260223 1 192.168.104.77 51069]
*[DOUBANGO INFO]: ICE Pair(8, 9114756780671369214): [tK09uR7JfWunKSj 2130706431 1 134.209.96.220 49958] -> [607528754 2122194687 1 192.168.100.101 61342]
*[DOUBANGO INFO]: ICE Pair(9, 9115038255648079358): [xc9MKNDCUKVRdSc 2130706175 1 10.130.109.245 41532] -> [1436999646 2122260223 1 192.168.104.77 51069]
*[DOUBANGO INFO]: ICE Pair(10, 9114756780671368702): [xc9MKNDCUKVRdSc 2130706175 1 10.130.109.245 41532] -> [607528754 2122194687 1 192.168.100.101 61342]
*[DOUBANGO INFO]: ICE Pair(11, 9115038255648078846): [n1C39wtUotIjZ2m 2130705919 1 10.15.0.17 40854] -> [1436999646 2122260223 1 192.168.104.77 51069]
*[DOUBANGO INFO]: ICE Pair(12, 9114756780671368190): [n1C39wtUotIjZ2m 2130705919 1 10.15.0.17 40854] -> [607528754 2122194687 1 192.168.100.101 61342]
*[DOUBANGO INFO]: ICE: end building pairs
*[DOUBANGO INFO]: ICE CTX::run -- START
*[DOUBANGO INFO]: State machine: ICE_Started_2_GatheringHostCandidates_X_GatherHostCandidates
*[DOUBANGO INFO]: Timer manager run()::enter
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 46965
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.130.109.245:46964]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.130.109.245
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 41914
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [134.209.96.220:41914]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 134.209.96.220
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 49448
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.15.0.17:49448]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.15.0.17
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidates_2_GatheringHostCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE-STUN enabled and we have STUN servers
*[DOUBANGO INFO]: ICE callback: Gathering host candidates succeed
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidatesDone_2_GatheringReflexiveCandidates_X_GatherReflexiveCandidates
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=0,rto=0
*[DOUBANGO INFO]: STUN request timedout at 0, rc = 3, rto=0
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: ICE CTX::run -- START
*[DOUBANGO INFO]: State machine: ICE_Started_2_GatheringHostCandidates_X_GatherHostCandidates
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 40008
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.130.109.245:40008]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.130.109.245
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 40716
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [134.209.96.220:40716]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 134.209.96.220
*[DOUBANGO INFO]: trying create sockets retry_count: 1 
*[DOUBANGO INFO]: random local port between 40000 and 49999 is 40421
*[DOUBANGO INFO]: RTP/RTCP manager[Begin]: Trying to bind to random ports [10.15.0.17:40420]
*[DOUBANGO INFO]: RTP/RTCP manager[End]: Trying to bind to random ports
*[DOUBANGO INFO]: local ip address = 10.15.0.17
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidates_2_GatheringHostCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE-STUN enabled and we have STUN servers
*[DOUBANGO INFO]: ICE callback: Gathering host candidates succeed
*[DOUBANGO INFO]: State machine: ICE_GatheringHostCandidatesDone_2_GatheringReflexiveCandidates_X_GatherReflexiveCandidates
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=0,rto=0
*[DOUBANGO INFO]: STUN request timedout at 0, rc = 3, rto=0
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: TIMER MANAGER -- START
*[DOUBANGO INFO]: Timer manager run()::enter
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=41914, fd=31, already_skipped(0)=no
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=41915, fd=32, already_skipped(1)=no
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=40716, fd=37, already_skipped(0)=no
*[DOUBANGO INFO]: Skipping redundant candidate address=134.209.96.220 and port=40717, fd=38, already_skipped(1)=no
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: ICE reflexive candidates gathering ...srv_addr=sbc2.entro-lab.com,srv_port=3478,tv_sec=0,tv_usec=500000,rto=500
*[DOUBANGO INFO]: TIMER MANAGER -- START
*[DOUBANGO INFO]: STUN request timedout at 3, rc = 3, rto=500
*[DOUBANGO INFO]: srflx_addr_count_added=0, srflx_addr_count_skipped=2
*[DOUBANGO INFO]: Candidate: bKeKRjoGjtl11Je 1 udp 2130706431 134.209.96.220 41914 typ host tr udp fd 31
*[DOUBANGO INFO]: Candidate: O5SxC1WexkyP8IH 1 udp 2130706175 10.130.109.245 46964 typ host tr udp fd 30
*[DOUBANGO INFO]: Candidate: O5SxC1WexkyP8IH 2 udp 2130706174 10.130.109.245 46965 typ host tr udp fd 29
*[DOUBANGO INFO]: Candidate: bKeKRjoGjtl11Je 2 udp 2130706430 134.209.96.220 41915 typ host tr udp fd 32
*[DOUBANGO INFO]: Candidate: p1wRvcGN34ceJFR 1 udp 2130705919 10.15.0.17 49448 typ host tr udp fd 33
*[DOUBANGO INFO]: Candidate: p1wRvcGN34ceJFR 2 udp 2130705918 10.15.0.17 49449 typ host tr udp fd 34
*[DOUBANGO INFO]: State machine: ICE_fsm_GatheringReflexiveCandidates_2_GatheringReflexiveCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE callback: Gathering reflexive candidates succeed
*[DOUBANGO INFO]: State machine: ICE_Any_2_GatheringCompleted_X_GatheringComplet
*[DOUBANGO INFO]: ICE callback: Gathering candidates completed
*[DOUBANGO INFO]: STUN request timedout at 3, rc = 3, rto=500
*[DOUBANGO INFO]: srflx_addr_count_added=0, srflx_addr_count_skipped=2
*[DOUBANGO INFO]: Candidate: BE0JzLcaruObHNh 1 udp 2130706431 134.209.96.220 40716 typ host tr udp fd 37
*[DOUBANGO INFO]: Candidate: rNidr8gxSeWRazc 1 udp 2130706175 10.130.109.245 40008 typ host tr udp fd 35
*[DOUBANGO INFO]: Candidate: rNidr8gxSeWRazc 2 udp 2130706174 10.130.109.245 40009 typ host tr udp fd 36
*[DOUBANGO INFO]: Candidate: BE0JzLcaruObHNh 2 udp 2130706430 134.209.96.220 40717 typ host tr udp fd 38
*[DOUBANGO INFO]: Candidate: EsOBkG0VTfHr1ub 1 udp 2130705919 10.15.0.17 40420 typ host tr udp fd 40
*[DOUBANGO INFO]: Candidate: EsOBkG0VTfHr1ub 2 udp 2130705918 10.15.0.17 40421 typ host tr udp fd 39
*[DOUBANGO INFO]: State machine: ICE_fsm_GatheringReflexiveCandidates_2_GatheringReflexiveCandidatesDone_X_Success
*[DOUBANGO INFO]: ICE callback: Gathering reflexive candidates succeed
*[DOUBANGO INFO]: State machine: ICE_Any_2_GatheringCompleted_X_GatheringComplet
*[DOUBANGO INFO]: ICE callback: Gathering candidates completed
*[DOUBANGO INFO]: State machine: c0000_Started_2_Outgoing_X_oINVITE
*[DOUBANGO INFO]: tdav_consumer_audio_init()
*[DOUBANGO INFO]: Create SpeexDSP denoiser
*[DOUBANGO INFO]: Create SpeexDSP jitter buffer
*[DOUBANGO INFO]: Video 'zero-artifacts' option = no
*[DOUBANGO INFO]: *** tdav_codec_vp8_dtor destroyed ***
*[DOUBANGO INFO]: tdav_codec_vp8_close_encoder(begin)
*[DOUBANGO INFO]: tdav_codec_vp8_close_encoder(end)
*[DOUBANGO INFO]: tdav_codec_vp8_close_decoder(begin)
*[DOUBANGO INFO]: tdav_codec_vp8_close_decoder(end)
*[DOUBANGO INFO]: tdav_codec_h264_common_deinit
*[DOUBANGO INFO]: ICE enabled on RTP manager
*[DOUBANGO INFO]: dtls.remote.setup=active
***[DOUBANGO ERROR]: function: "_sdp_pcfgs_from_sdp()" 
file: "src/tdav_session_av.c" 
line: "2331" 
MSG: Failed to find 'acap' with tag=2
***[DOUBANGO ERROR]: function: "_sdp_pcfgs_from_sdp()" 
file: "src/tdav_session_av.c" 
line: "2331" 
MSG: Failed to find 'acap' with tag=2
*[DOUBANGO INFO]: ICE enabled on RTP manager
*[DOUBANGO INFO]: dtls.remote.setup=active
***[DOUBANGO ERROR]: function: "_sdp_pcfgs_from_sdp()" 
file: "src/tdav_session_av.c" 
line: "2331" 
MSG: Failed to find 'acap' with tag=2
***[DOUBANGO ERROR]: function: "_sdp_pcfgs_from_sdp()" 
file: "src/tdav_session_av.c" 
line: "2331" 
MSG: Failed to find 'acap' with tag=2
*[DOUBANGO INFO]: 

SEND: INVITE sip:pepsi@178.128.23.171 SIP/2.0
Via: SIP/2.0/UDP 134.209.96.220:10060;branch=z9hG4bK-4978329433;rport
From: <sip:test@178.128.23.171:5060>;tag=4475839840
To: <sip:pepsi@178.128.23.171>
Contact: <sip:test@134.209.96.220:10060;ws-src-ip=180.183.42.233;ws-src-port=6437;ws-src-proto=wss;transport=udp>
Call-ID: cdaa8845-3244-3005-96bb-016257305035
CSeq: 525413703 INVITE
Content-Type: application/sdp
Content-Length: 3329
Max-Forwards: 70
User-Agent: webrtc2sip Media Server 2.7.0

v=0
o=doubango 1983 678902 IN IP4 134.209.96.220
s=-
c=IN IP4 134.209.96.220
t=0 0
a=acap:1 setup:actpass
a=tcap:1 UDP/TLS/RTP/SAVPF UDP/TLS/RTP/SAVP RTP/SAVPF RTP/SAVP RTP/AVPF
a=acap:4 fingerprint:sha-1 D0:DB:F1:6B:BE:B3:D3:05:CF:8C:C3:77:33:33:BB:10:D6:B7:D6:92
a=acap:3 fingerprint:sha-256 54:D5:97:02:75:47:B9:DE:B5:02:98:CF:91:BD:DD:35:42:F8:07:AA:9A:0D:F9:A6:BB:3C:03:3A:B4:01:5A:87
a=acap:1 setup:actpass
m=audio 40716 RTP/AVP 111 0 101 8
c=IN IP4 134.209.96.220
a=ptime:20
a=minptime:1
a=maxptime:255
a=silenceSupp:off - - - -
a=rtpmap:111 opus/48000/2
a=fmtp:111 maxplaybackrate=48000; sprop-maxcapturerate=48000; stereo=0; sprop-stereo=0; useinbandfec=0; usedtx=0
a=rtpmap:0 PCMU/8000/1
a=rtpmap:101 telephone-event/8000/1
a=fmtp:101 0-16
a=rtpmap:8 PCMA/8000/1
a=acap:5 crypto:1 AES_CM_128_HMAC_SHA1_80 inline:/RYFfL9EreVwoOQei2XEtUQJu4iM9w3H9s9Zc7Ap
a=acap:6 crypto:2 AES_CM_128_HMAC_SHA1_32 inline:xP5g4mIKTp6Nou62LdAQ/al5w8LeuOkoXiuZcRoM
a=pcfg:1 t=1 a=1,2,4|3
a=pcfg:2 t=2 a=1,2,4|3
a=pcfg:3 t=3 a=5,6
a=pcfg:4 t=4 a=5,6
a=pcfg:5 t=5
a=sendrecv
a=rtcp-mux
a=ssrc:822594717 cname:(null)
a=ssrc:822594717 mslabel:6994f7d1-6ce9-4fbd-acfd-84e5131ca2e2
a=ssrc:822594717 label:doubango@audio
a=ice-ufrag:eDo6Z6r15cVnTlj
a=ice-pwd:Ose2ELapiyCKwF3GJHb04C
a=candidate:BE0JzLcaruObHNh 1 udp 2130706431 134.209.96.220 40716 typ host tr udp fd 37
a=candidate:rNidr8gxSeWRazc 1 udp 2130706175 10.130.109.245 40008 typ host tr udp fd 35
a=candidate:rNidr8gxSeWRazc 2 udp 2130706174 10.130.109.245 40009 typ host tr udp fd 36
a=candidate:BE0JzLcaruObHNh 2 udp 2130706430 134.209.96.220 40717 typ host tr udp fd 38
a=candidate:EsOBkG0VTfHr1ub 1 udp 2130705919 10.15.0.17 40420 typ host tr udp fd 40
a=candidate:EsOBkG0VTfHr1ub 2 udp 2130705918 10.15.0.17 40421 typ host tr udp fd 39
m=video 41914 RTP/AVP 100 104
c=IN IP4 134.209.96.220
a=rtcp-fb:* ccm fir
a=rtcp-fb:* nack
a=rtcp-fb:* goog-remb
a=rtcp-fb:* doubs-jcng
a=label:4
a=content:main
a=rtpmap:100 VP8/90000
a=imageattr:100 recv [x=[128:16:640],y=[96:16:480]] send [x=[128:16:640],y=[96:16:480]]
a=rtpmap:104 H264/90000
a=imageattr:104 recv [x=[128:16:640],y=[96:16:480]] send [x=[128:16:640],y=[96:16:480]]
a=fmtp:104 profile-level-id=42e016;max-mbps=20250;max-fs=1200; impl=openh264
a=acap:5 crypto:1 AES_CM_128_HMAC_SHA1_80 inline:qCnu/5384BM4AslIF4BKebdUIjA0WnQkpZ5wYmxU
a=acap:6 crypto:2 AES_CM_128_HMAC_SHA1_32 inline:aWfNJabuCowkHdY4SQMMlZpEo+a1xac+L3eBKfcm
a=pcfg:1 t=1 a=1,2,4|3
a=pcfg:2 t=2 a=1,2,4|3
a=pcfg:3 t=3 a=5,6
a=pcfg:4 t=4 a=5,6
a=pcfg:5 t=5
a=sendrecv
a=rtcp-mux
a=ssrc:666044236 cname:(null)
a=ssrc:666044236 mslabel:6994f7d1-6ce9-4fbd-acfd-84e5131ca2e2
a=ssrc:666044236 label:doubango@video
a=ice-ufrag:M7kx4epxEB4lGNY
a=ice-pwd:Egv4byyHMzKV7HosEVmYnI
a=candidate:bKeKRjoGjtl11Je 1 udp 2130706431 134.209.96.220 41914 typ host tr udp fd 31
a=candidate:O5SxC1WexkyP8IH 1 udp 2130706175 10.130.109.245 46964 typ host tr udp fd 30
a=candidate:O5SxC1WexkyP8IH 2 udp 2130706174 10.130.109.245 46965 typ host tr udp fd 29
a=candidate:bKeKRjoGjtl11Je 2 udp 2130706430 134.209.96.220 41915 typ host tr udp fd 32
a=candidate:p1wRvcGN34ceJFR 1 udp 2130705919 10.15.0.17 49448 typ host tr udp fd 33
a=candidate:p1wRvcGN34ceJFR 2 udp 2130705918 10.15.0.17 49449 typ host tr udp fd 34



*[DOUBANGO INFO]: 

RECV:SIP/2.0 100 trying -- your call is important to us
Via: SIP/2.0/UDP 134.209.96.220:10060;branch=z9hG4bK-4978329433;rport=10060;received=134.209.96.220
From: <sip:test@178.128.23.171:5060>;tag=4475839840
To: <sip:pepsi@178.128.23.171>
Call-ID: cdaa8845-3244-3005-96bb-016257305035
CSeq: 525413703 INVITE
Server: kamailio (5.2.1 (x86_64/linux))
Content-Length: 0




*[DOUBANGO INFO]: State machine: x0000_Any_2_Any_X_i1xx
*[DOUBANGO INFO]: 

RECV:SIP/2.0 180 Ringing
Via: SIP/2.0/UDP 134.209.96.220:10060;received=134.209.96.220;branch=z9hG4bK-4978329433;rport=10060
From: <sip:test@178.128.23.171:5060>;tag=4475839840
To: <sip:pepsi@178.128.23.171>;tag=HVy1SLJ
Call-ID: cdaa8845-3244-3005-96bb-016257305035
CSeq: 525413703 INVITE
User-Agent: Linphone_iPhone11.8_iOS12.3.1/4.0.2-2-gf18fb2a09 (belle-sip/1.6.3)
Supported: replaces, outbound, gruu
Record-route: <sip:178.128.23.171;lr>




*[DOUBANGO INFO]: State machine: x0000_Any_2_Any_X_i1xx
*[DOUBANGO INFO]: 

RECV:SIP/2.0 200 Ok
Via: SIP/2.0/UDP 134.209.96.220:10060;received=134.209.96.220;branch=z9hG4bK-4978329433;rport=10060
From: <sip:test@178.128.23.171:5060>;tag=4475839840
To: <sip:pepsi@178.128.23.171>;tag=HVy1SLJ
Call-ID: cdaa8845-3244-3005-96bb-016257305035
CSeq: 525413703 INVITE
User-Agent: Linphone_iPhone11.8_iOS12.3.1/4.0.2-2-gf18fb2a09 (belle-sip/1.6.3)
Supported: replaces, outbound, gruu
Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO, UPDATE
Contact: <sip:pepsi@182.232.31.63:56025;app-id=org.linphone.phone.voip.prod;pn-type=apple;pn-tok=FB5DC2C616053B2406EB0382700D25254CCACB1524C6110FBD449D3E1F0A37BE;pn-msg-str=IM_MSG;pn-call-str=IC_MSG;pn-call-snd=notes_of_the_optimistic.caf;pn-msg-snd=msg.caf;pn-timeout=0;pn-silent=1;transport=udp>;expires=3600;+sip.instance="<urn:uuid:fac68202-bea0-40d7-8adf-5fa9ea3d0ab1>";+org.linphone.specs=groupchat
Content-Type: application/sdp
Content-Length: 1133
Record-route: <sip:178.128.23.171;lr>

v=0
o=pepsi 155 1885 IN IP4 182.232.31.63
s=Talk
c=IN IP4 182.232.31.63
t=0 0
a=ice-pwd:31978d37d81f4b55f8688861
a=ice-ufrag:bf2f9561
m=audio 7226 RTP/AVP 111 0 101 8
c=IN IP4 182.232.31.63
a=rtpmap:111 opus/48000/2
a=fmtp:111 useinbandfec=1
a=rtpmap:101 telephone-event/8000
a=candidate:1 1 UDP 2130706303 10.186.253.209 7226 typ host
a=candidate:1 2 UDP 2130706302 10.186.253.209 7227 typ host
a=candidate:2 1 UDP 1694498687 182.232.31.63 7226 typ srflx raddr 10.186.253.209 rport 7226
a=candidate:2 2 UDP 1694498686 182.232.31.63 7227 typ srflx raddr 10.186.253.209 rport 7227
m=video 9236 RTP/AVP 100 104
c=IN IP4 182.232.31.63
a=rtpmap:100 VP8/90000
a=rtpmap:104 H264/90000
a=fmtp:104 profile-level-id=42801F
a=candidate:1 1 UDP 2130706303 10.186.253.209 9236 typ host
a=candidate:1 2 UDP 2130706302 10.186.253.209 9237 typ host
a=candidate:2 1 UDP 1694498687 182.232.31.63 9236 typ srflx raddr 10.186.253.209 rport 9236
a=candidate:2 2 UDP 1694498686 182.232.31.63 9237 typ srflx raddr 10.186.253.209 rport 9237
a=rtcp-fb:* trr-int 1000
a=rtcp-fb:* nack
a=rtcp-fb:100 ccm fir
a=rtcp-fb:104 ccm fir



*[DOUBANGO INFO]: State machine: c0000_Outgoing_2_Connected_X_i2xxINVITE
*[DOUBANGO INFO]: tnet_ice_ctx_set_remote_candidates(ufrag=bf2f9561, pwd=31978d37d81f4b55f8688861, is_controlling=1, is_ice_jingle=0, use_rtcpmux=0)
*[DOUBANGO INFO]: tnet_ice_ctx_set_remote_candidates(ufrag=bf2f9561, pwd=31978d37d81f4b55f8688861, is_controlling=1, is_ice_jingle=0, use_rtcpmux=0)
*[DOUBANGO INFO]: m_lines_count=0,
is_dtls_fingerprint_changed=0,
is_sdes_crypto_changed=0,
is_ice_enabled=0,
is_ice_restart=0,
is_ro_hold_resume_changed=0,
is_ro_provisional_final_matching=0,
is_ro_media_lines_changed=0,
is_ro_network_info_changed=0,
is_ro_loopback_address=0,
is_media_type_changed=0,
is_ro_codecs_changed=0
is_local_encoder_still_ok=0

*[DOUBANGO INFO]: new m_lines_count = 0 -> 2
*[DOUBANGO INFO]: [OPUS] Trying to match [fmtp:useinbandfec=1]
*[DOUBANGO INFO]: [H.264] Trying to match [fmtp:profile-level-id=42801F]
*[DOUBANGO INFO]: 

SEND: ACK sip:pepsi@182.232.31.63:56025;app-id=org.linphone.phone.voip.prod;pn-type=apple;pn-tok=FB5DC2C616053B2406EB0382700D25254CCACB1524C6110FBD449D3E1F0A37BE;pn-msg-str=IM_MSG;pn-call-str=IC_MSG;pn-call-snd=notes_of_the_optimistic.caf;pn-msg-snd=msg.caf;pn-timeout=0;pn-silent=1;transport=udp SIP/2.0
Via: SIP/2.0/UDP 134.209.96.220:10060;branch=z9hG4bK-4711729655;rport
From: <sip:test@178.128.23.171:5060>;tag=4475839840
To: <sip:pepsi@178.128.23.171>;tag=HVy1SLJ
Contact: <sip:test@134.209.96.220:10060;ws-src-ip=180.183.42.233;ws-src-port=6437;ws-src-proto=wss;transport=udp>
Call-ID: cdaa8845-3244-3005-96bb-016257305035
CSeq: 525413703 ACK
Content-Length: 0
Max-Forwards: 70
Route: <sip:178.128.23.171;lr>
User-Agent: webrtc2sip Media Server 2.7.0
```